### PR TITLE
Fix language parameter passthrough and instruct validation

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1526,7 +1526,7 @@ async function generateCustomVoice() {
     const text = document.getElementById('cv-text').value.trim();
     const language = document.getElementById('cv-language').value;
     const speed = parseFloat(document.getElementById('cv-speed').value);
-    const instruct = document.getElementById('cv-instruct').value.trim() || null;
+    const instruct = document.getElementById('cv-instruct').value.trim();
 
     if (!text) {
         showToast('Please enter text to synthesize', 'warning');
@@ -1541,7 +1541,6 @@ async function generateCustomVoice() {
     const btn = document.getElementById('cv-generate-btn');
     btn.classList.add('loading');
     btn.disabled = true;
-
 
     try {
         const startTime = performance.now();


### PR DESCRIPTION
## Summary

- **Language selection ignored**: The `language` parameter from the UI was never passed to `generate_audio()` via `generate_with_temp_dir()`. All 6 call sites now pass `lang_code=request.language.lower()`, so selecting "German", "Chinese", etc. in the WebUI actually affects TTS output instead of always defaulting to English.
- **422 on empty instruct**: The frontend sent `null` for the `instruct` field when left blank, but the Pydantic model expected `str`. Fixed on both sides: frontend now sends `""`, backend accepts `Optional[str]`.
- **Validation error logging**: Added a `RequestValidationError` handler that logs field-level details server-side, making future 422 errors debuggable from logs.

## Changes

| File | Change |
|------|--------|
| `server.py` | Pass `lang_code` to all 6 `generate_with_temp_dir` calls |
| `server.py` | `CustomVoiceRequest.instruct`: `str` → `Optional[str]` |
| `server.py` | Add `validation_exception_handler` for 422 logging |
| `static/app.js` | Remove `|| null` from instruct assignment |

## Test plan

- [ ] Select "German" (or any non-English language) in Custom Voice tab → verify log shows `Language: german` instead of `Language: en`
- [ ] Leave instruct field empty in Custom Voice → verify no 422 error
- [ ] Send `null` for instruct via curl → verify no 422 error
- [ ] Test Voice Design and Voice Clone tabs with non-English language selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)